### PR TITLE
1658 request timeout async worker

### DIFF
--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -611,11 +611,11 @@ class WorkerClass(Setting):
         A string referring to one of the following bundled classes:
 
         * ``sync``
-        * ``eventlet`` - Requires eventlet >= 0.9.7 (or install it via 
+        * ``eventlet`` - Requires eventlet >= 0.9.7 (or install it via
           ``pip install gunicorn[eventlet]``)
-        * ``gevent``   - Requires gevent >= 0.13 (or install it via 
+        * ``gevent``   - Requires gevent >= 0.13 (or install it via
           ``pip install gunicorn[gevent]``)
-        * ``tornado``  - Requires tornado >= 0.2 (or install it via 
+        * ``tornado``  - Requires tornado >= 0.2 (or install it via
           ``pip install gunicorn[tornado]``)
         * ``gthread``  - Python 2 requires the futures package to be installed
           (or install it via ``pip install gunicorn[gthread]``)
@@ -652,7 +652,7 @@ class WorkerThreads(Setting):
         If it is not defined, the default is ``1``.
 
         This setting only affects the Gthread worker type.
-        
+
         .. note::
            If you try to use the ``sync`` worker type and set the ``threads``
            setting to more than 1, the ``gthread`` worker type will be used
@@ -746,6 +746,20 @@ class GracefulTimeout(Setting):
         After receiving a restart signal, workers have this much time to finish
         serving requests. Workers still alive after the timeout (starting from
         the receipt of the restart signal) are force killed.
+        """
+
+
+class RequestTimeout(Setting):
+    name = "request_timeout"
+    section = "Worker Processes"
+    cli = ["--request-timeout"]
+    meta = "INT"
+    validator = validate_pos_int
+    type = int
+    default = 0
+    desc = """\
+        Worker is killed and restarted if the request running in it takes more
+        than this many seconds.
         """
 
 

--- a/gunicorn/workers/async.py
+++ b/gunicorn/workers/async.py
@@ -8,7 +8,6 @@ import errno
 import socket
 import ssl
 import sys
-import signal
 
 import gunicorn.http as http
 import gunicorn.http.wsgi as wsgi

--- a/gunicorn/workers/ggevent.py
+++ b/gunicorn/workers/ggevent.py
@@ -32,6 +32,7 @@ from gunicorn.http.wsgi import sendfile as o_sendfile
 
 VERSION = "gevent/%s gunicorn/%s" % (gevent.__version__, gunicorn.__version__)
 
+
 def _gevent_sendfile(fdout, fdin, offset, nbytes):
     while True:
         try:
@@ -41,6 +42,7 @@ def _gevent_sendfile(fdout, fdin, offset, nbytes):
                 wait_write(fdout)
             else:
                 raise
+
 
 def patch_sendfile():
     from gunicorn.http import wsgi
@@ -86,6 +88,9 @@ class GeventWorker(AsyncWorker):
 
     def timeout_ctx(self):
         return gevent.Timeout(self.cfg.keepalive, False)
+
+    def request_timeout(self):
+        return gevent.Timeout(self.cfg.request_timeout, False)
 
     def run(self):
         servers = []


### PR DESCRIPTION
PR opened on main gunicorn repo https://github.com/benoitc/gunicorn/pull/1730

---

This PR allows request timeout for asynchronous gevent workers. It adds a `--request-timeout` setting