### PR TITLE
Bump request timeout default

### DIFF
--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -756,7 +756,7 @@ class RequestTimeout(Setting):
     meta = "INT"
     validator = validate_pos_int
     type = int
-    default = 0
+    default = 120
     desc = """\
         Worker is killed and restarted if the request running in it takes more
         than this many seconds.


### PR DESCRIPTION
Bugfix:

if you don't provide `--request-timeout` to gunicorn, the default in the code is 0. And `gevent.Timeout()` consider 0 not to be False. So all the requests timeout